### PR TITLE
Fixed memory leak in KinFitter

### DIFF
--- a/python/myutils/kinFitterXbb.py
+++ b/python/myutils/kinFitterXbb.py
@@ -378,6 +378,11 @@ class kinFitterXbb(AddCollectionsModule):
                         self._b(self.bDict[syst]['llbbr_eta_fit'])[0]         = -99 
                         self._b(self.bDict[syst]['llbbr_mass_fit'])[0]        = -99
 
+                    del cons_MZ
+                    del cons_x
+                    del cons_y
+                    del fitter
+
                 else:
                     # no two resolved jets
                     self._b(self.bDict[syst]['H_pt_fit'])[0]          = -1 


### PR DESCRIPTION
The heap generated by running the kinematic fit had lots of "cons_x" and "cons_y" when run through `strings`, so I think the leak was actually from the creation of the constraints here. ROOT likes to store things in a global hash table, so Python's garbage collection doesn't always work.

I'm running jobs with all the systematics right now. They don't seem to cause any swapping yet after almost 2 hours, but I'll keep an eye on them.
