### PR TITLE
Actually Fixed Memory Leak

### DIFF
--- a/HelperClasses/KinFitter/TKinFitter.cc
+++ b/HelperClasses/KinFitter/TKinFitter.cc
@@ -180,6 +180,18 @@ void TKinFitter::resetParams() {
 
 TKinFitter::~TKinFitter() {
 
+  for (auto* element: _constraints)
+    delete element;
+  _constraints.clear();
+
+  for (auto* element: _measParticles)
+    delete element;
+  _measParticles.clear();
+
+  for (auto* element: _unmeasParticles)
+    delete element;
+  _unmeasParticles.clear();
+
 }
 
 void TKinFitter::countMeasParams() {


### PR DESCRIPTION
Following the clues in #128 I ended up putting a printout in the fit constraint destructor and putting `del` statements all over the place. `del` stopped working after `fitter.addConstraint()` https://github.com/piberger/Xbb/blob/master/python/myutils/kinFitterXbb.py#L274

I think what was actually happening is Python or ROOT gave ownership of the constraints to the fitter. Deleting the Python proxy for the constraints wasn't enough. The fix was to explicitly delete constraints in the fitter's destructor.